### PR TITLE
Add support for koajs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/examples/9-koajs/index.html
+++ b/examples/9-koajs/index.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html>
+    <head>
+        <title>Eureca.io test</title>
+        <script src="/eureca.js"></script>
+    </head>
+    <body>
+        <h4>eureca.io test</h4>
+        <script>
+         var client = new Eureca.Client();
+         client.exports.clientHello = function() {
+             return 'hello from client';
+         };
+         client.ready(function(serverProxy) {
+             serverProxy.clientReady().onReady(function(result) {
+                 console.log('told server we are ready:' + result);
+             });
+             serverProxy.serverHello().onReady(function(result) {
+                 console.log('client got from server:' + result);
+             });
+         });
+
+        </script>
+    </body>
+</html>

--- a/examples/9-koajs/server.js
+++ b/examples/9-koajs/server.js
@@ -1,0 +1,29 @@
+var app = require('koa')();
+var serve = require('koa-static');
+var Eureca = require('eureca.io');
+var router = require('koa-router')();
+
+var eurecaServer = new Eureca.Server({allow: ['clientHello']});
+var client;
+eurecaServer.exports.serverHello = function() {
+    console.log('client called server hello');
+    return 'hello from server';
+};
+
+eurecaServer.exports.clientReady = function() {
+    client = this.clientProxy;
+    return 'server got client ready';
+    client.clientHello().onReady(function(result) {
+        console.log('server got from client:' + result);
+    });
+};
+router.get('/projects', function *(next) {
+    this.body = {
+        projects: ['proj1', 'proj2']
+    };
+});
+app.use(router.routes()).use(router.allowedMethods());
+app.use(serve('./'));
+var server = require('http').createServer(app.callback());
+eurecaServer.attach(server);
+server.listen(8000);

--- a/lib/EurecaServer.js
+++ b/lib/EurecaServer.js
@@ -1509,7 +1509,7 @@ var Eureca;
          */
         Server.prototype.attach = function (server) {
             var app = server;
-            if (server._events.request !== undefined && server.routes === undefined)
+            if (server._events && server._events.request !== undefined && server.routes === undefined && server._events.request.on)
                 app = server._events.request;
             //this._checkHarmonyProxies();
             this.allowedF = this.settings.allow || [];

--- a/src/Server.class.ts
+++ b/src/Server.class.ts
@@ -480,8 +480,9 @@ module Eureca  {
         public attach (server:any) {
 
             var app = server;
-            if (server._events.request !== undefined && server.routes === undefined) app = server._events.request;
-
+            var requestHandler = server;
+            if (server._events && server._events.request !== undefined && server.routes === undefined) app = server._events.request;
+            if (app.on) requestHandler = app;
             //this._checkHarmonyProxies();
 
             this.allowedF = this.settings.allow || [];
@@ -516,7 +517,7 @@ module Eureca  {
             else  //Fallback to nodejs
             {
                 
-                app.on('request', function (request, response) {
+                requestHandler.on('request', function (request, response) {
                     if (request.method === 'GET') {
                         if (request.url.split('?')[0] === _clientUrl) {
                             _this.sendScript(request, response, _prefix);

--- a/src/Server.class.ts
+++ b/src/Server.class.ts
@@ -480,9 +480,7 @@ module Eureca  {
         public attach (server:any) {
 
             var app = server;
-            var requestHandler = server;
-            if (server._events && server._events.request !== undefined && server.routes === undefined) app = server._events.request;
-            if (app.on) requestHandler = app;
+            if (server._events && server._events.request !== undefined && server.routes === undefined && server._events.request.on) app = server._events.request;
             //this._checkHarmonyProxies();
 
             this.allowedF = this.settings.allow || [];
@@ -517,7 +515,7 @@ module Eureca  {
             else  //Fallback to nodejs
             {
                 
-                requestHandler.on('request', function (request, response) {
+                app.on('request', function (request, response) {
                     if (request.method === 'GET') {
                         if (request.url.split('?')[0] === _clientUrl) {
                             _this.sendScript(request, response, _prefix);


### PR DESCRIPTION
The following request adds support for koajs and I suspect other app servers though I have not tested it. The changes are minor. In the case of koajs, we pass in the http server, there is no 'app.on' function hanging off of app._events.request. In this case you want to use the original server passed in.

This change explicitly checks if 'on' is hanging off of app, or if we should use the server passed in. I've tested this in my project using koa. Please let me know if there are any changes you would like to see.